### PR TITLE
Add ValueError test for display_in_columns

### DIFF
--- a/test_utility.py
+++ b/test_utility.py
@@ -58,6 +58,11 @@ class TestUtility(unittest.TestCase):
         self.assertIn("Item3", output)
         self.assertIn("Item4", output)
 
+    def test_display_in_columns_invalid_columns(self):
+        """Ensure ValueError is raised for non-positive column counts."""
+        with self.assertRaises(ValueError):
+            Utility.display_in_columns(["Item1"], columns=0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- test Utility.display_in_columns with an invalid column count

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683b962d7e148330a06f845bc8ac4bbe