### PR TITLE
Fix link description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `config.json` file stores the path to the save game file:
 
 ## 🔗 Useful Links
 
-- [https://www.oldgames.sk](https://www.oldgames.sk/docs/Might-and-Magic/1/index.html) -  
+- [Oldgames documentation](https://www.oldgames.sk/docs/Might-and-Magic/1/index.html)  
 
 
 # ⚠️ Disclaimer


### PR DESCRIPTION
## Summary
- clarify the Oldgames link wording in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement PyYAML)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683b962026008330a249a5c71a9bbd6a