### PR TITLE
Fix message typo

### DIFF
--- a/charedit.py
+++ b/charedit.py
@@ -410,8 +410,8 @@ def main() -> None:
     # Warn the user to create a backup before proceeding
     Logger.warn("\n*** Warning: Before making any changes, ensure you have created a backup copy of your save file. ***")
 
-    Logger.warn('''\nBe cautious when editing values: game mechanics may alter them dynamically. 
-Unintended affects may occur if values are set to extremes.\n''')
+    Logger.warn('''\nBe cautious when editing values: game mechanics may alter them dynamically.
+Unintended effects may occur if values are set to extremes.\n''')
 
     # Proceed with editing
     output_file = save_game_file_path


### PR DESCRIPTION
## Summary
- fix minor typo in charedit warnings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683b95feec248330adeb29408c881748